### PR TITLE
Allow Silex v1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.3",
         "aws/aws-sdk-php": "2.*",
-        "silex/silex": "1.0.*"
+        "silex/silex": "~1.0"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
This changes the Silex version constraint to `~1.0`, so this service provider can be installed alongside Silex v1.1.0
