### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7",
+        "phpunit/phpunit": "~4.8.35",
         "squizlabs/php_codesniffer": "^2.3"
     }
 }

--- a/tests/AwsServiceProviderTest.php
+++ b/tests/AwsServiceProviderTest.php
@@ -17,11 +17,12 @@
 namespace Aws\Silex;
 
 use Silex\Application;
+use PHPUnit\Framework\TestCase;
 
 /**
  * AwsServiceProvider test cases
  */
-class AwsServiceProviderTest extends \PHPUnit_Framework_TestCase
+class AwsServiceProviderTest extends TestCase
 {
     public function testRegisterAwsServiceProvider()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.